### PR TITLE
WIP Refactor query handling to support singular and plural PK queries

### DIFF
--- a/lib/GraphQL/Plugin/Convert/DBIC.pm
+++ b/lib/GraphQL/Plugin/Convert/DBIC.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use GraphQL::Schema;
 use GraphQL::Debug qw(_debug);
-use Lingua::EN::Inflect::Number qw(to_S);
+use Lingua::EN::Inflect::Number qw(to_S to_PL);
 use Carp qw(confess);
 
 our $VERSION = "0.10";
@@ -314,9 +314,20 @@ sub to_graphql {
         my $name = $_;
         my $type = $name2type{$name};
         my $pksearch_name = lcfirst $name;
+        my $pksearch_name_plural = to_PL($pksearch_name);
         my $input_search_name = "search$name";
         # TODO now only one deep, no handle fragments or abstract types
         $root_value{$pksearch_name} = sub {
+          my ($args, $content, $info) = @_;
+          my @subfieldrels = _subfieldrels($name, \%name2rel21, $info->{field_nodes});
+          DEBUG and _debug('DBIC.root_value', @subfieldrels);
+          $dbic_schema_cb->()->resultset($name)->find({
+            $_ => $args->{$_},
+          }, {
+            prefetch => \@subfieldrels,
+          });
+        };
+        $root_value{$pksearch_name_plural} = sub {
           my ($args, $context, $info) = @_;
           my @subfieldrels = _subfieldrels($name, \%name2rel21, $info->{field_nodes});
           DEBUG and _debug('DBIC.root_value', @subfieldrels);
@@ -345,19 +356,33 @@ sub to_graphql {
           ];
         };
         (
-          # the PKs query
-          keys %{ $name2pk21{$name} } ? ($pksearch_name => {
-            type => _apply_modifier('list', $name),
-            args => {
-              map {
-                $_ => {
-                  type => _apply_modifier('non_null', _apply_modifier('list',
-                    _apply_modifier('non_null', $type->{fields}{$_}{type})
-                  ))
-                }
-              } keys %{ $name2pk21{$name} }
+          keys %{ $name2pk21{$name} } ? (
+            # the PK (singular) query
+            $pksearch_name => {
+              type => $name,
+              args => {
+                map {
+                  $_ => {
+                    type =>
+                      _apply_modifier('non_null', $type->{fields}{$_}{type})
+                  }
+                } keys %{ $name2pk21{$name} }
+              },
             },
-          }) : (),
+            # the PKs query
+            $pksearch_name_plural => {
+              type => _apply_modifier('list', $name),
+              args => {
+                map {
+                  $_ => {
+                    type => _apply_modifier('non_null', _apply_modifier('list',
+                      _apply_modifier('non_null', $type->{fields}{$_}{type})
+                    ))
+                  }
+                } keys %{ $name2pk21{$name} }
+              },
+            },
+          ) : (),
           $input_search_name => {
             description => 'input to search',
             type => _apply_modifier('list', $name),

--- a/t/02-execute.t
+++ b/t/02-execute.t
@@ -35,14 +35,14 @@ my $converted = GraphQL::Plugin::Convert::DBIC->to_graphql(
 subtest 'execute pk + deeper query' => sub {
   my $doc = <<'EOF';
 {
-  blog(id: [1, 2]) {
+  blogs(id: [1, 2]) {
     id
     title
     tags {
       name
     }
   }
-  photo(id: [4730349774, 4730337840]) {
+  photos(id: [4730349774, 4730337840]) {
     id
     description
     photosets {
@@ -59,7 +59,7 @@ EOF
     ],
     {
       data => {
-        blog => [
+        blogs => [
           {
             id => 1,
             tags => [ { name => "personal" }, { name => "test" } ],
@@ -71,7 +71,7 @@ EOF
             title => "Tech",
           }
         ],
-        photo => [
+        photos => [
           {
             description => '',
             id => '4730337840',
@@ -155,7 +155,7 @@ EOF
 subtest 'execute update mutation' => sub {
   my $doc = <<'EOF';
 query q {
-  photo(id: ["4730349774", "4656987762"]) {
+  photos(id: ["4730349774", "4656987762"]) {
     id
     locality
   }
@@ -179,7 +179,7 @@ EOF
     ],
     {
       data => {
-        photo => [
+        photos => [
           { id => '4656987762', locality => 'Chico' },
           { id => '4730349774', locality => 'Fort Lauderdale' },
         ],
@@ -211,14 +211,14 @@ EOF
       $converted->{schema}, $doc, $converted->{root_value},
       (undef) x 2, 'q', $converted->{resolver},
     ],
-    { data => { photo => $expected } },
+    { data => { photos => $expected } },
   );
 };
 
 subtest 'execute delete mutation' => sub {
   my $doc = <<'EOF';
 query q {
-  blogTag(id: [6]) {
+  blogTags(id: [6]) {
     id
     name
   }
@@ -235,7 +235,7 @@ EOF
     ],
     {
       data => {
-        blogTag => [ {
+        blogTags => [ {
           id => 6,
           name => 'something',
         } ],
@@ -256,7 +256,7 @@ EOF
       $converted->{schema}, $doc, $converted->{root_value},
       (undef) x 2, 'q', $converted->{resolver},
     ],
-    { data => { blogTag => [] } },
+    { data => { blogTags => [] } },
   );
 };
 

--- a/t/snapshots/01-dbicschema_t/schema
+++ b/t/snapshots/01-dbicschema_t/schema
@@ -322,12 +322,18 @@ input PhotosetSearchInput {
 }
 
 type Query {
-  blog(id: [Int!]!): [Blog]
-  blogTag(id: [Int!]!): [BlogTag]
-  mysql(id: [String!]!): [Mysql]
-  pg(id: [String!]!): [Pg]
-  photo(id: [String!]!): [Photo]
-  photoset(id: [String!]!): [Photoset]
+  blog(id: Int!): Blog
+  blogTag(id: Int!): BlogTag
+  blogTags(id: [Int!]!): [BlogTag]
+  blogs(id: [Int!]!): [Blog]
+  mysql(id: String!): Mysql
+  mysqls(id: [String!]!): [Mysql]
+  pg(id: String!): Pg
+  pgs(id: [String!]!): [Pg]
+  photo(id: String!): Photo
+  photos(id: [String!]!): [Photo]
+  photoset(id: String!): Photoset
+  photosets(id: [String!]!): [Photoset]
   "input to search"
   searchBlog(input: BlogSearchInput!): [Blog]
   "input to search"

--- a/t/snapshots/01-dbicschema_t/schema_simple
+++ b/t/snapshots/01-dbicschema_t/schema_simple
@@ -319,12 +319,18 @@ input PhotosetSearchInput {
 }
 
 type Query {
-  blog(id: [Int!]!): [Blog]
-  blogTag(id: [Int!]!): [BlogTag]
-  mysql(id: [String!]!): [Mysql]
-  pg(id: [String!]!): [Pg]
-  photo(id: [String!]!): [Photo]
-  photoset(id: [String!]!): [Photoset]
+  blog(id: Int!): Blog
+  blogTag(id: Int!): BlogTag
+  blogTags(id: [Int!]!): [BlogTag]
+  blogs(id: [Int!]!): [Blog]
+  mysql(id: String!): Mysql
+  mysqls(id: [String!]!): [Mysql]
+  pg(id: String!): Pg
+  pgs(id: [String!]!): [Pg]
+  photo(id: String!): Photo
+  photos(id: [String!]!): [Photo]
+  photoset(id: String!): Photoset
+  photosets(id: [String!]!): [Photoset]
   "input to search"
   searchBlog(input: BlogSearchInput!): [Blog]
   "input to search"

--- a/t/snapshots/03-sqlread_t/schema
+++ b/t/snapshots/03-sqlread_t/schema
@@ -58,8 +58,10 @@ type Mutation {
 }
 
 type Query {
-  author(id: [Int!]!): [Author]
-  module(id: [Int!]!): [Module]
+  author(id: Int!): Author
+  authors(id: [Int!]!): [Author]
+  module(id: Int!): Module
+  modules(id: [Int!]!): [Module]
   "input to search"
   searchAuthor(input: AuthorSearchInput!): [Author]
   "input to search"

--- a/t/snapshots/04-dbicschema_t/schema
+++ b/t/snapshots/04-dbicschema_t/schema
@@ -157,9 +157,12 @@ type Mutation {
 }
 
 type Query {
-  department(dept_no: [String!]!): [Department]
-  employee(emp_no: [Int!]!): [Employee]
-  salary(from_date: [DateTime!]!): [Salary]
+  department(dept_no: String!): Department
+  departments(dept_no: [String!]!): [Department]
+  employee(emp_no: Int!): Employee
+  employees(emp_no: [Int!]!): [Employee]
+  salaries(from_date: [DateTime!]!): [Salary]
+  salary(from_date: DateTime!): Salary
   "input to search"
   searchCurrentDeptEmp(input: CurrentDeptEmpSearchInput!): [CurrentDeptEmp]
   "input to search"
@@ -176,7 +179,8 @@ type Query {
   searchSalary(input: SalarySearchInput!): [Salary]
   "input to search"
   searchTitle(input: TitleSearchInput!): [Title]
-  title(from_date: [DateTime!]!, title: [String!]!): [Title]
+  title(from_date: DateTime!, title: String!): Title
+  titles(from_date: [DateTime!]!, title: [String!]!): [Title]
 }
 
 type Salary {


### PR DESCRIPTION
Not ready for merging (tests will fail), consider a request for comment. This will somewhat change existing behavior and might lead to breaking changes.

The idea is to follow GraphQL convention for using singular vs plural query forms to return single item or a list of items, e.g. `user(id: Int!): User` vs `users(id: [Int!]!): [User]`. Not having a way to request single object leads to some inconvenient gymnastics on the client side.

Another point of interest is non-null requirement for PK argument in plural queries. Presently the list is strictly required so requesting the whole dataset involves passing in a list of arguments with zero members. I think this is a superficial requirement, making the list optional will be more readable. That would be a small but potentially breaking change, not implemented in this PR.

If the approach is ok I'll follow up based on comments and fix the tests.