### PR TITLE
Postgres network types

### DIFF
--- a/lib/GraphQL/Plugin/Convert/DBIC.pm
+++ b/lib/GraphQL/Plugin/Convert/DBIC.pm
@@ -42,6 +42,9 @@ my %GRAPHQL_TYPE2SQLS = (
     'tinytext',
     'mediumtext',
     'longtext',
+    # pgsql
+    'cidr',
+    'inet',
   ],
   Int => [
     'bigint',


### PR DESCRIPTION
This just avoids the unknown data type error when a DBIC object refers to Postgres network types