### PR TITLE
fixed problem with getting one item

### DIFF
--- a/lib/GraphQL/Plugin/Convert/DBIC.pm
+++ b/lib/GraphQL/Plugin/Convert/DBIC.pm
@@ -324,9 +324,9 @@ sub to_graphql {
           my ($args, $content, $info) = @_;
           my @subfieldrels = _subfieldrels($name, \%name2rel21, $info->{field_nodes});
           DEBUG and _debug('DBIC.root_value', @subfieldrels);
-          $dbic_schema_cb->()->resultset($name)->find({
-            $_ => $args->{$_},
-          }, {
+          $dbic_schema_cb->()->resultset($name)->find(
+          $args,
+          {
             prefetch => \@subfieldrels,
           });
         };

--- a/t/02-execute.t
+++ b/t/02-execute.t
@@ -260,4 +260,30 @@ EOF
   );
 };
 
+subtest 'just get one blog' => sub {
+  my $doc = <<'EOF';
+{
+  blog(id: 1) {
+    id
+    title
+  }
+}
+EOF
+  run_test(
+    [
+      $converted->{schema}, $doc, $converted->{root_value},
+      (undef) x 3, $converted->{resolver},
+    ],
+    {
+      data => {
+        blog => 
+        {
+          id => 1,
+          title => "Hello!",
+        },
+      }
+    }
+  );
+};
+
 done_testing;


### PR DESCRIPTION
Hi,

Small fix.  For the case where you are looking for a single entry by PK (for example)

```
{
  blog(id: 1) {
    id
    title
  }
}
```

That didn't work for me.  Looks like for at least my version of Perl (5.26) that "$_" is not defined in the code at that point (and this wouldn't work for multi-field PKs anyway).  Trivial patch includes test case.

It's a tiny fix however for situations where the PK is multi field we might need more fixes like this in other bits of the code (and test cases).  Let me know if you are open to getting patches around supporting composite keys like that.  Multi field PK comes up a lot for for.  Thanks!

John


