### PR TITLE
use simple schema instance instead of coderef

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl extension GraphQL-Plugin-Convert-DBIC
 
+TBD
+ - Changed the 'to_graphql' function to accept just a DBIC schema instance
+   and not a coderef.  We will continue to accept the coderef style for
+   backcompatibility but its considered depracated.
+
 0.13	Fri  5 Apr 04:56:21 BST 2019
  - fix get-one - thanks @jjn1056
 

--- a/lib/SQL/Translator/Producer/GraphQL.pm
+++ b/lib/SQL/Translator/Producer/GraphQL.pm
@@ -15,9 +15,7 @@ sub produce {
   my $perl = dbic_produce($dbic_translator);
   eval $perl;
   die "Failed to make DBIx::Class::Schema: $@" if $@;
-  my $converted = GraphQL::Plugin::Convert::DBIC->to_graphql(
-    sub { $dbic_schema_class->connect }
-  );
+  my $converted = GraphQL::Plugin::Convert::DBIC->to_graphql($dbic_schema_class->connect);
   $converted->{schema}->to_doc;
 }
 

--- a/t/01-dbicschema.t
+++ b/t/01-dbicschema.t
@@ -9,15 +9,14 @@ use SQL::Translator;
 use_ok 'GraphQL::Plugin::Convert::DBIC';
 
 my $dbic_class = 'Schema';
-my $converted = GraphQL::Plugin::Convert::DBIC->to_graphql(
-  sub { $dbic_class->connect }
-);
+my $schema = $dbic_class->connect;
+my $converted = GraphQL::Plugin::Convert::DBIC->to_graphql($schema);
 my $got = $converted->{schema}->to_doc;
 is_deeply_snapshot $got, 'schema';
 
 my $sqlt = SQL::Translator->new(
   parser => 'SQL::Translator::Parser::DBIx::Class',
-  parser_args => { dbic_schema => $dbic_class->connect },
+  parser_args => { dbic_schema => $schema},
   producer => 'GraphQL',
 );
 $got = $sqlt->translate or die $sqlt->error;

--- a/t/02-execute.t
+++ b/t/02-execute.t
@@ -28,9 +28,7 @@ my $dir = tempdir( CLEANUP => 1 );
 my ($tfh, $filename) = tempfile( DIR => $dir );
 print $tfh do { open my $fh, 't/test.db'; binmode $fh; join '', <$fh> };
 close $tfh;
-my $converted = GraphQL::Plugin::Convert::DBIC->to_graphql(
-  sub { $dbic_class->connect("dbi:SQLite:$filename") }
-);
+my $converted = GraphQL::Plugin::Convert::DBIC->to_graphql($dbic_class->connect("dbi:SQLite:$filename"));
 
 subtest 'execute pk + deeper query' => sub {
   my $doc = <<'EOF';

--- a/t/04-dbicschema.t
+++ b/t/04-dbicschema.t
@@ -9,9 +9,7 @@ use SQL::Translator;
 use_ok 'GraphQL::Plugin::Convert::DBIC';
 
 my $dbic_class = 'Schema';
-my $converted = GraphQL::Plugin::Convert::DBIC->to_graphql(
-  sub { $dbic_class->connect }
-);
+my $converted = GraphQL::Plugin::Convert::DBIC->to_graphql($dbic_class->connect);
 my $got = $converted->{schema}->to_doc;
 is_deeply_snapshot $got, 'schema';
 


### PR DESCRIPTION
As mentioned on IRC, DBIC has really great re-connection logic.  I've never had to worry about if the connection was live as long as the database was up!  Slightly more simple to use and possibly avoid some gotcha we are not considering.